### PR TITLE
Update tenant extensions with website/org fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,11 +76,11 @@ cdm-spark-manager-client = { git = "https://github.com/kbase/cdm-kube-spark-mana
 datalake-mcp-server-client = { git = "https://github.com/BERDataLakehouse/datalake-mcp-server-client.git", rev = "v0.0.8" }
 jupyter-ai-cborg = { git = "https://github.com/kbaseincubator/cdm-jupyter-ai-cborg.git" }
 minio-manager-service-client = { git = "https://github.com/BERDataLakehouse/minio_manager_service_client.git", rev = "v0.0.18" }
-berdl-access-request = { git = "https://github.com/BERDataLakehouse/berdl_access_request_extension.git", rev = "v0.0.8" }
+berdl-access-request = { url = "https://github.com/BERDataLakehouse/berdl_access_request_extension/releases/download/pr-17/berdl_access_request-0.0.9.dev6-py3-none-any.whl" }
 cdm-task-service-client = { git = "https://github.com/kbase/cdm-task-service-client", rev = "0.2.3" }
 berdl-task-browser = { url = "https://github.com/BERDataLakehouse/berdl_task_browser/releases/download/0.2.1/berdl_task_browser-0.2.1-py3-none-any.whl" }
 berdl-jupyterlab-coreui = { url = "https://github.com/BERDataLakehouse/BERDL_JupyterLab_CoreUI/releases/download/0.0.6/berdl_jupyterlab_coreui-0.0.6-py3-none-any.whl" }
-tenant-data-browser = { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/0.4.3/tenant_data_browser-0.4.3-py3-none-any.whl" }
+tenant-data-browser = { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/pr-28/tenant_data_browser-0.4.4.dev8-py3-none-any.whl" }
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,11 +76,11 @@ cdm-spark-manager-client = { git = "https://github.com/kbase/cdm-kube-spark-mana
 datalake-mcp-server-client = { git = "https://github.com/BERDataLakehouse/datalake-mcp-server-client.git", rev = "v0.0.9" }
 jupyter-ai-cborg = { git = "https://github.com/kbaseincubator/cdm-jupyter-ai-cborg.git" }
 minio-manager-service-client = { git = "https://github.com/BERDataLakehouse/minio_manager_service_client.git", rev = "v0.0.18" }
-berdl-access-request = { url = "https://github.com/BERDataLakehouse/berdl_access_request_extension/releases/download/pr-17/berdl_access_request-0.0.9.dev6-py3-none-any.whl" }
+berdl-access-request = { url = "https://github.com/BERDataLakehouse/berdl_access_request_extension/releases/download/v0.0.9/berdl_access_request-0.0.9-py3-none-any.whl" }
 cdm-task-service-client = { git = "https://github.com/kbase/cdm-task-service-client", rev = "0.2.3" }
 berdl-task-browser = { url = "https://github.com/BERDataLakehouse/berdl_task_browser/releases/download/0.2.1/berdl_task_browser-0.2.1-py3-none-any.whl" }
 berdl-jupyterlab-coreui = { url = "https://github.com/BERDataLakehouse/BERDL_JupyterLab_CoreUI/releases/download/0.0.6/berdl_jupyterlab_coreui-0.0.6-py3-none-any.whl" }
-tenant-data-browser = { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/pr-28/tenant_data_browser-0.4.4.dev8-py3-none-any.whl" }
+tenant-data-browser = { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/0.4.4/tenant_data_browser-0.4.4-py3-none-any.whl" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -347,14 +347,14 @@ wheels = [
 
 [[package]]
 name = "berdl-access-request"
-version = "0.0.9.dev6"
-source = { url = "https://github.com/BERDataLakehouse/berdl_access_request_extension/releases/download/pr-17/berdl_access_request-0.0.9.dev6-py3-none-any.whl" }
+version = "0.0.9"
+source = { url = "https://github.com/BERDataLakehouse/berdl_access_request_extension/releases/download/v0.0.9/berdl_access_request-0.0.9-py3-none-any.whl" }
 dependencies = [
     { name = "jupyter-server" },
     { name = "pyyaml" },
 ]
 wheels = [
-    { url = "https://github.com/BERDataLakehouse/berdl_access_request_extension/releases/download/pr-17/berdl_access_request-0.0.9.dev6-py3-none-any.whl", hash = "sha256:eedf18b069c9a651a6e8d637153bece626e4da45497bd4ad1b66521a5146e849" },
+    { url = "https://github.com/BERDataLakehouse/berdl_access_request_extension/releases/download/v0.0.9/berdl_access_request-0.0.9-py3-none-any.whl", hash = "sha256:e2b049fe1080de0cb187f31942bd5d6be5153540bab52ced43ef9cd6f557570c" },
 ]
 
 [package.metadata]
@@ -444,7 +444,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "attrs", specifier = "==25.4.0" },
-    { name = "berdl-access-request", url = "https://github.com/BERDataLakehouse/berdl_access_request_extension/releases/download/pr-17/berdl_access_request-0.0.9.dev6-py3-none-any.whl" },
+    { name = "berdl-access-request", url = "https://github.com/BERDataLakehouse/berdl_access_request_extension/releases/download/v0.0.9/berdl_access_request-0.0.9-py3-none-any.whl" },
     { name = "berdl-jupyterlab-coreui", url = "https://github.com/BERDataLakehouse/BERDL_JupyterLab_CoreUI/releases/download/0.0.6/berdl_jupyterlab_coreui-0.0.6-py3-none-any.whl" },
     { name = "berdl-task-browser", url = "https://github.com/BERDataLakehouse/berdl_task_browser/releases/download/0.2.1/berdl_task_browser-0.2.1-py3-none-any.whl" },
     { name = "biopython", specifier = "==1.86" },
@@ -483,7 +483,7 @@ requires-dist = [
     { name = "seaborn", specifier = "==0.13.2" },
     { name = "sidecar", specifier = "==0.8.1" },
     { name = "sqlalchemy", specifier = "==2.0.47" },
-    { name = "tenant-data-browser", url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/pr-28/tenant_data_browser-0.4.4.dev8-py3-none-any.whl" },
+    { name = "tenant-data-browser", url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/0.4.4/tenant_data_browser-0.4.4-py3-none-any.whl" },
     { name = "trino", specifier = "==0.337.0" },
     { name = "websockets", specifier = "==16.0" },
 ]
@@ -5145,13 +5145,13 @@ wheels = [
 
 [[package]]
 name = "tenant-data-browser"
-version = "0.4.4.dev8"
-source = { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/pr-28/tenant_data_browser-0.4.4.dev8-py3-none-any.whl" }
+version = "0.4.4"
+source = { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/0.4.4/tenant_data_browser-0.4.4-py3-none-any.whl" }
 dependencies = [
     { name = "jupyter-server" },
 ]
 wheels = [
-    { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/pr-28/tenant_data_browser-0.4.4.dev8-py3-none-any.whl", hash = "sha256:a09ea109775a4b2186989f51e0cfab0cd0e71bea80d4e386c223a24ed80a063e" },
+    { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/0.4.4/tenant_data_browser-0.4.4-py3-none-any.whl", hash = "sha256:8aa5c0101c9b64f31324f76a44d84497043658ad26628bc23029d617f796339d" },
 ]
 
 [package.metadata]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -347,11 +347,20 @@ wheels = [
 
 [[package]]
 name = "berdl-access-request"
-version = "0.0.8"
-source = { git = "https://github.com/BERDataLakehouse/berdl_access_request_extension.git?rev=v0.0.8#6a1e1bb01459f6803466349c99993ed2a14a6593" }
+version = "0.0.9.dev6"
+source = { url = "https://github.com/BERDataLakehouse/berdl_access_request_extension/releases/download/pr-17/berdl_access_request-0.0.9.dev6-py3-none-any.whl" }
 dependencies = [
     { name = "jupyter-server" },
     { name = "pyyaml" },
+]
+wheels = [
+    { url = "https://github.com/BERDataLakehouse/berdl_access_request_extension/releases/download/pr-17/berdl_access_request-0.0.9.dev6-py3-none-any.whl", hash = "sha256:eedf18b069c9a651a6e8d637153bece626e4da45497bd4ad1b66521a5146e849" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "jupyter-server", specifier = ">=2.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]
@@ -435,7 +444,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "attrs", specifier = "==25.4.0" },
-    { name = "berdl-access-request", git = "https://github.com/BERDataLakehouse/berdl_access_request_extension.git?rev=v0.0.8" },
+    { name = "berdl-access-request", url = "https://github.com/BERDataLakehouse/berdl_access_request_extension/releases/download/pr-17/berdl_access_request-0.0.9.dev6-py3-none-any.whl" },
     { name = "berdl-jupyterlab-coreui", url = "https://github.com/BERDataLakehouse/BERDL_JupyterLab_CoreUI/releases/download/0.0.6/berdl_jupyterlab_coreui-0.0.6-py3-none-any.whl" },
     { name = "berdl-task-browser", url = "https://github.com/BERDataLakehouse/berdl_task_browser/releases/download/0.2.1/berdl_task_browser-0.2.1-py3-none-any.whl" },
     { name = "biopython", specifier = "==1.86" },
@@ -474,7 +483,7 @@ requires-dist = [
     { name = "seaborn", specifier = "==0.13.2" },
     { name = "sidecar", specifier = "==0.8.1" },
     { name = "sqlalchemy", specifier = "==2.0.47" },
-    { name = "tenant-data-browser", url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/0.4.3/tenant_data_browser-0.4.3-py3-none-any.whl" },
+    { name = "tenant-data-browser", url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/pr-28/tenant_data_browser-0.4.4.dev8-py3-none-any.whl" },
     { name = "trino", specifier = "==0.337.0" },
     { name = "websockets", specifier = "==16.0" },
 ]
@@ -5136,13 +5145,13 @@ wheels = [
 
 [[package]]
 name = "tenant-data-browser"
-version = "0.4.3"
-source = { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/0.4.3/tenant_data_browser-0.4.3-py3-none-any.whl" }
+version = "0.4.4.dev8"
+source = { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/pr-28/tenant_data_browser-0.4.4.dev8-py3-none-any.whl" }
 dependencies = [
     { name = "jupyter-server" },
 ]
 wheels = [
-    { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/0.4.3/tenant_data_browser-0.4.3-py3-none-any.whl", hash = "sha256:b3ca2b86eb87efa11d663436bfe9fada2460220f9a90a2d27391794446ce9f6f" },
+    { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/pr-28/tenant_data_browser-0.4.4.dev8-py3-none-any.whl", hash = "sha256:a09ea109775a4b2186989f51e0cfab0cd0e71bea80d4e386c223a24ed80a063e" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
## Summary
- Update **tenant-data-browser** to `0.4.4.dev8` ([PR #28](https://github.com/BERDataLakehouse/tenant-data-browser/pull/28)): adds website and organization fields to the Data Dictionary tenant info panel
- Update **berdl-access-request** to `0.0.9.dev6` ([PR #17](https://github.com/BERDataLakehouse/berdl_access_request_extension/pull/17)): adds website and organization fields to the tenants landing page cards

Both extensions also switch their governance API calls to `berdl_notebook_utils` wrappers for consistency with other governance calls in each codebase.

## Test plan
- [ ] `uv sync` resolves without errors
- [ ] Docker image builds successfully
- [ ] Data Dictionary shows tenant website/org in info panel
- [ ] Tenants landing page shows org/website on cards