### PR TITLE
CDM-543: Bump tenant-data-browser to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ berdl-access-request = { url = "https://github.com/BERDataLakehouse/berdl_access
 cdm-task-service-client = { git = "https://github.com/kbase/cdm-task-service-client", rev = "0.2.3" }
 berdl-task-browser = { url = "https://github.com/BERDataLakehouse/berdl_task_browser/releases/download/0.2.1/berdl_task_browser-0.2.1-py3-none-any.whl" }
 berdl-jupyterlab-coreui = { url = "https://github.com/BERDataLakehouse/BERDL_JupyterLab_CoreUI/releases/download/0.0.6/berdl_jupyterlab_coreui-0.0.6-py3-none-any.whl" }
-tenant-data-browser = { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/0.4.4/tenant_data_browser-0.4.4-py3-none-any.whl" }
+tenant-data-browser = { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/0.5.0/tenant_data_browser-0.5.0-py3-none-any.whl" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -485,7 +485,7 @@ requires-dist = [
     { name = "seaborn", specifier = "==0.13.2" },
     { name = "sidecar", specifier = "==0.8.1" },
     { name = "sqlalchemy", specifier = "==2.0.49" },
-    { name = "tenant-data-browser", url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/0.4.4/tenant_data_browser-0.4.4-py3-none-any.whl" },
+    { name = "tenant-data-browser", url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/0.5.0/tenant_data_browser-0.5.0-py3-none-any.whl" },
     { name = "trino", specifier = "==0.337.0" },
     { name = "websockets", specifier = "==16.0" },
 ]
@@ -5151,13 +5151,13 @@ wheels = [
 
 [[package]]
 name = "tenant-data-browser"
-version = "0.4.4"
-source = { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/0.4.4/tenant_data_browser-0.4.4-py3-none-any.whl" }
+version = "0.5.0"
+source = { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/0.5.0/tenant_data_browser-0.5.0-py3-none-any.whl" }
 dependencies = [
     { name = "jupyter-server" },
 ]
 wheels = [
-    { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/0.4.4/tenant_data_browser-0.4.4-py3-none-any.whl", hash = "sha256:8aa5c0101c9b64f31324f76a44d84497043658ad26628bc23029d617f796339d" },
+    { url = "https://github.com/BERDataLakehouse/tenant-data-browser/releases/download/0.5.0/tenant_data_browser-0.5.0-py3-none-any.whl", hash = "sha256:71d8d5eb98bfa47f6497ad08cbfb954d2ba81f627963c5566a716ee0aa16b9d1" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
## Summary
- Update `tenant-data-browser` wheel URL from 0.4.4 to 0.5.0
- Refresh `uv.lock`

Release: https://github.com/BERDataLakehouse/tenant-data-browser/releases/tag/0.5.0
Brings in BERDataLakehouse/tenant-data-browser#37 (Data Dictionary schema view renders column data type and comment).

## Test plan
- [ ] CI passes